### PR TITLE
Changed SearchBar to Material 3 and added clear text Button

### DIFF
--- a/app/src/main/java/com/example/dictionaryapp/ui/components/DisplayMeaning.kt
+++ b/app/src/main/java/com/example/dictionaryapp/ui/components/DisplayMeaning.kt
@@ -1,24 +1,9 @@
 package com.example.dictionaryapp.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.example.dictionaryapp.ui.screens.DictionaryUiState
-import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material3.CircularProgressIndicator
+import com.example.dictionaryapp.ui.screens.ErrorScreen
+import com.example.dictionaryapp.ui.screens.LoadingScreen
 
 @Composable
 fun DisplayMeaning(dictionaryUiState: DictionaryUiState) {
@@ -26,51 +11,5 @@ fun DisplayMeaning(dictionaryUiState: DictionaryUiState) {
         is DictionaryUiState.Error -> ErrorScreen(e = dictionaryUiState.e)
         is DictionaryUiState.Loading -> LoadingScreen()
         is DictionaryUiState.Success -> DisplayDefinition(definition = dictionaryUiState.definition)
-    }
-}
-
-@Composable
-fun ErrorScreen(e: Exception) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Icon(
-            imageVector = Icons.Default.ErrorOutline,
-            contentDescription = "Error",
-            tint = MaterialTheme.colorScheme.error,
-            modifier = Modifier.size(64.dp)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Oops! Something went wrong.",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.error
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = e.localizedMessage ?: "Unknown error",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 8.dp),
-            maxLines = 3
-        )
-    }
-}
-
-@Composable
-fun LoadingScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        CircularProgressIndicator(
-            color = MaterialTheme.colorScheme.primary,
-            strokeWidth = 4.dp,
-            modifier = Modifier.size(48.dp)
-        )
     }
 }

--- a/app/src/main/java/com/example/dictionaryapp/ui/components/MySearchBar.kt
+++ b/app/src/main/java/com/example/dictionaryapp/ui/components/MySearchBar.kt
@@ -1,60 +1,63 @@
 package com.example.dictionaryapp.ui.components
 
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.dp
 
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MySearchBar(
-    searchQuery: String,
-    onQueryChange: (String) -> Unit,
-    onSearchClick: () -> Unit,
+fun MySearchBarM3(
+    onSearchClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    TextField(
-        value = searchQuery,
-        onValueChange = onQueryChange,
-        placeholder = { Text("Search a word") },
-        singleLine = true,
-        trailingIcon = {
-            IconButton(
-                onClick = onSearchClick
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
-                    tint = MaterialTheme.colorScheme.primary
+    val textFieldState = rememberTextFieldState()
+
+    SearchBar(
+            inputField = {
+                SearchBarDefaults.InputField(
+                    query = textFieldState.text.toString(),
+                    onQueryChange = { textFieldState.edit { replace(0, length, it) } },
+                    onSearch = onSearchClick,
+                    expanded = false,
+                    onExpandedChange = {},
+                    placeholder = { Text("Search a word") },
+                    leadingIcon = {
+                        IconButton(
+                            onClick = { onSearchClick(textFieldState.text.toString()) }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Search,
+                                contentDescription = "Search",
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    },
+                    trailingIcon = {
+                        if (textFieldState.text.isNotEmpty()) {
+                            IconButton(
+                                onClick = { textFieldState.clearText() }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = "Clear",
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
                 )
-            }
-        },
-        keyboardOptions = KeyboardOptions.Default.copy(
-            imeAction = ImeAction.Search
-        ),
-        keyboardActions = KeyboardActions(
-            onSearch = {
-                onSearchClick()
-            }
-        ),
-        colors = TextFieldDefaults.colors(
-            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-            focusedIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent,
-            focusedTextColor = MaterialTheme.colorScheme.onSurface,
-            unfocusedTextColor = MaterialTheme.colorScheme.onSurface
-        ),
-        modifier = modifier
-            .fillMaxWidth()
-            .height(56.dp),
-        shape = RoundedCornerShape(28.dp)
-    )
+            },
+            expanded = false,
+            onExpandedChange = {},
+            modifier = modifier,
+            colors = SearchBarDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        ) { }
 }

--- a/app/src/main/java/com/example/dictionaryapp/ui/screens/ErrorScreen.kt
+++ b/app/src/main/java/com/example/dictionaryapp/ui/screens/ErrorScreen.kt
@@ -1,0 +1,51 @@
+package com.example.dictionaryapp.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorScreen(e: Exception) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.ErrorOutline,
+            contentDescription = "Error",
+            tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(64.dp)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Oops! Something went wrong.",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.error
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = e.localizedMessage ?: "Unknown error",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 8.dp),
+            maxLines = 3
+        )
+    }
+}
+

--- a/app/src/main/java/com/example/dictionaryapp/ui/screens/LoadingScreen.kt
+++ b/app/src/main/java/com/example/dictionaryapp/ui/screens/LoadingScreen.kt
@@ -1,0 +1,25 @@
+package com.example.dictionaryapp.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LoadingScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            color = MaterialTheme.colorScheme.primary,
+            strokeWidth = 4.dp,
+            modifier = Modifier.size(48.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/dictionaryapp/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/com/example/dictionaryapp/ui/screens/SearchScreen.kt
@@ -1,38 +1,25 @@
 package com.example.dictionaryapp.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.dictionaryapp.ui.components.DisplayMeaning
-import com.example.dictionaryapp.ui.components.MySearchBar
+import com.example.dictionaryapp.ui.components.MySearchBarM3
 
 @Preview(showBackground = true)
 @Composable
 fun SearchScreen(modifier: Modifier = Modifier) {
-    var searchQuery by remember { mutableStateOf("") }
-
-    val onQueryChange: (String) -> Unit = { searchQuery = it }
+    var showResults by remember { mutableStateOf(false) }
 
     val dictionaryViewModel: DictionaryViewModel = viewModel()
 
@@ -40,13 +27,14 @@ fun SearchScreen(modifier: Modifier = Modifier) {
 
     Column(modifier = modifier
         .fillMaxSize()
-        .padding(top = 16.dp, start = 16.dp, end = 16.dp)
+        .padding(horizontal = 16.dp)
     ) {
-        MySearchBar(searchQuery = searchQuery, onQueryChange = onQueryChange, onSearchClick = {
+        MySearchBarM3(onSearchClick = { searchQuery ->
+            showResults = true
             dictionaryViewModel.getDef(searchQuery)
             keyboardController?.hide()
         })
-        if (searchQuery.isNotBlank()) {
+        if (showResults) {
             DisplayMeaning(dictionaryUiState = dictionaryViewModel.dictionaryUiState)
         }
     }


### PR DESCRIPTION
This pull request introduces the following changes:

- Moved the ErrorScreen and LoadingScreen from DisplayMeaning.kt to a separate file in the screens folder.
- Changed MySearchBar into MySearchBarM3 which uses the experimental Material 3 SearchBar component.
- Added a showResults variable so it doesn't show a loading activity indicator as soon as the user types something. It only shows the loading screen after the search button is clicked at least once.
- Moved text handling into the search bar rather than passing it in as a parameter.